### PR TITLE
Reduce allocations for 6 & 7-card hand evaluations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PokerHandEvaluator"
 uuid = "18ed25b1-892a-4a3b-b8fc-1036dc9a6a89"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/PokerHandEvaluator.jl
+++ b/src/PokerHandEvaluator.jl
@@ -139,57 +139,6 @@ hand_type(th::CompactHandEval) =
 hand_rank(th::CompactHandEval) = th.rank
 
 """
-    combinations_6_choose_5(tup::Tuple)
-
-Unroll `Combinatorics.combinations` for all 5-card
-combinations given 6 cards.
-"""
-function combinations_6_choose_5(tup::Tuple)
-    @assert length(tup) == 6
-    return (
-         (tup[1], tup[2], tup[3], tup[4], tup[5]),
-         (tup[1], tup[2], tup[3], tup[4], tup[6]),
-         (tup[1], tup[2], tup[3], tup[5], tup[6]),
-         (tup[1], tup[2], tup[4], tup[5], tup[6]),
-         (tup[1], tup[3], tup[4], tup[5], tup[6]),
-         (tup[2], tup[3], tup[4], tup[5], tup[6]),
-    )
-end
-
-"""
-    combinations_7_choose_5(tup::Tuple)
-
-Unroll `Combinatorics.combinations` for all 5-card
-combinations given 7 cards.
-"""
-function combinations_7_choose_5(tup::Tuple)
-    @assert length(tup) == 7
-    return (
-        (tup[1], tup[2], tup[3], tup[4], tup[5]),
-        (tup[1], tup[2], tup[3], tup[4], tup[6]),
-        (tup[1], tup[2], tup[3], tup[4], tup[7]),
-        (tup[1], tup[2], tup[3], tup[5], tup[6]),
-        (tup[1], tup[2], tup[3], tup[5], tup[7]),
-        (tup[1], tup[2], tup[3], tup[6], tup[7]),
-        (tup[1], tup[2], tup[4], tup[5], tup[6]),
-        (tup[1], tup[2], tup[4], tup[5], tup[7]),
-        (tup[1], tup[2], tup[4], tup[6], tup[7]),
-        (tup[1], tup[2], tup[5], tup[6], tup[7]),
-        (tup[1], tup[3], tup[4], tup[5], tup[6]),
-        (tup[1], tup[3], tup[4], tup[5], tup[7]),
-        (tup[1], tup[3], tup[4], tup[6], tup[7]),
-        (tup[1], tup[3], tup[5], tup[6], tup[7]),
-        (tup[1], tup[4], tup[5], tup[6], tup[7]),
-        (tup[2], tup[3], tup[4], tup[5], tup[6]),
-        (tup[2], tup[3], tup[4], tup[5], tup[7]),
-        (tup[2], tup[3], tup[4], tup[6], tup[7]),
-        (tup[2], tup[3], tup[5], tup[6], tup[7]),
-        (tup[2], tup[4], tup[5], tup[6], tup[7]),
-        (tup[3], tup[4], tup[5], tup[6], tup[7]),
-    )
-end
-
-"""
     evaluate(cards::Card...)
     evaluate(::Card,::Card,::Card,::Card,::Card[,::Card,::Card])
     evaluate(::Tuple{Card,Card,Card,Card,Card[,Card,Card]})
@@ -235,23 +184,11 @@ end
 
 # Wrapper for 6 card hands:
 function evaluate_full(t::Tuple{<:Card,<:Card,<:Card,<:Card,<:Card,<:Card})
-    hand_ranks = map(combinations_6_choose_5(t)) do cards
-        hand_rank = evaluate5(cards)
-        hand_type = hand_type_binary_search(hand_rank)
-        (hand_rank, hand_type, cards)
-    end
-    i_max = argmin(map(x->x[1][1], hand_ranks))
-    return hand_ranks[i_max]
+    return best_hand_rank_from_6_cards_full(t)
 end
 # Wrapper for 7 card hands:
 function evaluate_full(t::Tuple{<:Card,<:Card,<:Card,<:Card,<:Card,<:Card,<:Card})
-    hand_ranks = map(combinations_7_choose_5(t)) do cards
-        hand_rank = evaluate5(cards)
-        hand_type = hand_type_binary_search(hand_rank)
-        (hand_rank, hand_type, cards)
-    end
-    i_max = argmin(map(x->x[1][1], hand_ranks))
-    return hand_ranks[i_max]
+    return best_hand_rank_from_7_cards_full(t)
 end
 
 #####
@@ -263,21 +200,14 @@ evaluate_compact(t::Tuple{<:Card,<:Card,<:Card,<:Card,<:Card}) = evaluate5(t)
 
 # Wrapper for 6 card hands:
 function evaluate_compact(t::Tuple{<:Card,<:Card,<:Card,<:Card,<:Card,<:Card})
-    hand_ranks = map(combinations_6_choose_5(t)) do cards
-        evaluate5(cards)
-    end
-    i_max = argmin(map(x->x[1], hand_ranks))
-    return hand_ranks[i_max]
+    return best_hand_rank_from_6_cards_compact(t)
 end
 # Wrapper for 7 card hands:
 function evaluate_compact(t::Tuple{<:Card,<:Card,<:Card,<:Card,<:Card,<:Card,<:Card})
-    hand_ranks = map(combinations_7_choose_5(t)) do cards
-        evaluate5(cards)
-    end
-    i_max = argmin(map(x->x[1], hand_ranks))
-    return hand_ranks[i_max]
+    return best_hand_rank_from_7_cards_compact(t)
 end
 
+include("best_hand_rank_from_n_cards.jl")
 include("HandCombinations.jl")
 include("evaluate5.jl")
 

--- a/src/best_hand_rank_from_n_cards.jl
+++ b/src/best_hand_rank_from_n_cards.jl
@@ -1,0 +1,102 @@
+#####
+##### Best n-card hand rank, from combinations.
+#####
+
+function min_hand_rank_full(eval1, cards)
+    hand_rank_2 = evaluate5(cards)
+    if first(eval1) <= hand_rank_2
+        return eval1
+    else
+        hand_type_2 = hand_type_binary_search(hand_rank_2)
+        return (hand_rank_2, hand_type_2, cards)
+    end
+end
+
+function min_hand_rank_compact(hand_rank_1, cards)
+    hand_rank_2 = evaluate5(cards)
+    if hand_rank_1 < hand_rank_2
+        return hand_rank_1
+    else
+        return hand_rank_2
+    end
+end
+
+function best_hand_rank_from_7_cards_full(c)
+    cards=(c[1],c[2],c[3],c[4],c[5]) # first combination
+
+    hand_rank = evaluate5(cards)
+    hand_type = hand_type_binary_search(hand_rank)
+    hr = (hand_rank, hand_type, cards)
+
+    cards=(c[1],c[2],c[3],c[4],c[6]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[1],c[2],c[3],c[4],c[7]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[1],c[2],c[3],c[5],c[6]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[1],c[2],c[3],c[5],c[7]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[1],c[2],c[3],c[6],c[7]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[1],c[2],c[4],c[5],c[6]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[1],c[2],c[4],c[5],c[7]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[1],c[2],c[4],c[6],c[7]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[1],c[2],c[5],c[6],c[7]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[1],c[3],c[4],c[5],c[6]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[1],c[3],c[4],c[5],c[7]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[1],c[3],c[4],c[6],c[7]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[1],c[3],c[5],c[6],c[7]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[1],c[4],c[5],c[6],c[7]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[2],c[3],c[4],c[5],c[6]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[2],c[3],c[4],c[5],c[7]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[2],c[3],c[4],c[6],c[7]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[2],c[3],c[5],c[6],c[7]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[2],c[4],c[5],c[6],c[7]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[3],c[4],c[5],c[6],c[7]); hr = min_hand_rank_full(hr, cards)
+    return hr
+end
+
+function best_hand_rank_from_6_cards_full(c)
+    cards=(c[1],c[2],c[3],c[4],c[5]); # first combination
+
+    hand_rank = evaluate5(cards);
+    hand_type = hand_type_binary_search(hand_rank);
+    hr = (hand_rank, hand_type, cards)
+
+    cards=(c[1],c[2],c[3],c[4],c[6]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[1],c[2],c[3],c[5],c[6]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[1],c[2],c[4],c[5],c[6]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[1],c[3],c[4],c[5],c[6]); hr = min_hand_rank_full(hr, cards)
+    cards=(c[2],c[3],c[4],c[5],c[6]); hr = min_hand_rank_full(hr, cards)
+    return hr
+end
+
+function best_hand_rank_from_7_cards_compact(c)
+    cards=(c[1],c[2],c[3],c[4],c[5]); hr = evaluate5(cards)
+    cards=(c[1],c[2],c[3],c[4],c[6]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[1],c[2],c[3],c[4],c[7]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[1],c[2],c[3],c[5],c[6]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[1],c[2],c[3],c[5],c[7]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[1],c[2],c[3],c[6],c[7]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[1],c[2],c[4],c[5],c[6]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[1],c[2],c[4],c[5],c[7]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[1],c[2],c[4],c[6],c[7]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[1],c[2],c[5],c[6],c[7]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[1],c[3],c[4],c[5],c[6]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[1],c[3],c[4],c[5],c[7]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[1],c[3],c[4],c[6],c[7]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[1],c[3],c[5],c[6],c[7]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[1],c[4],c[5],c[6],c[7]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[2],c[3],c[4],c[5],c[6]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[2],c[3],c[4],c[5],c[7]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[2],c[3],c[4],c[6],c[7]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[2],c[3],c[5],c[6],c[7]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[2],c[4],c[5],c[6],c[7]); hr = min_hand_rank_compact(hr, cards)
+    cards=(c[3],c[4],c[5],c[6],c[7]); hr = min_hand_rank_compact(hr, cards)
+    return hr
+end
+
+function best_hand_rank_from_6_cards_compact(c)
+    cards = (c[1],c[2],c[3],c[4],c[5]); hr = evaluate5(cards)
+    cards = (c[1],c[2],c[3],c[4],c[6]); hr = min_hand_rank_compact(hr, cards)
+    cards = (c[1],c[2],c[3],c[5],c[6]); hr = min_hand_rank_compact(hr, cards)
+    cards = (c[1],c[2],c[4],c[5],c[6]); hr = min_hand_rank_compact(hr, cards)
+    cards = (c[1],c[3],c[4],c[5],c[6]); hr = min_hand_rank_compact(hr, cards)
+    cards = (c[2],c[3],c[4],c[5],c[6]); hr = min_hand_rank_compact(hr, cards)
+    return hr
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -117,3 +117,33 @@ end
     @test_throws AssertionError PHE.hand_type_binary_search(0)
     @test_throws AssertionError PHE.hand_type_binary_search(7463)
 end
+
+if VERSION >= v"1.4"
+    @testset "Allocations" begin
+        cards_5 = (J♡,J♣,A♣,A♢,5♣);
+        cards_7 = (A♠,2♠,cards_5...);
+        cards_6 = (J♣,cards_5...);
+
+        # Compile first:
+        alloc_1 = @allocated CompactHandEval(cards_5)
+        alloc_2 = @allocated CompactHandEval(cards_6)
+        alloc_3 = @allocated CompactHandEval(cards_7)
+        alloc_4 = @allocated FullHandEval(cards_5)
+        alloc_5 = @allocated FullHandEval(cards_6)
+        alloc_6 = @allocated FullHandEval(cards_7)
+
+        alloc_1 = @allocated CompactHandEval(cards_5)
+        alloc_2 = @allocated CompactHandEval(cards_6)
+        alloc_3 = @allocated CompactHandEval(cards_7)
+        alloc_4 = @allocated FullHandEval(cards_5)
+        alloc_5 = @allocated FullHandEval(cards_6)
+        alloc_6 = @allocated FullHandEval(cards_7)
+
+        @test alloc_1 ≤ 32
+        @test alloc_2 ≤ 688
+        @test alloc_3 ≤ 944
+        @test alloc_4 ≤ 144
+        @test alloc_5 ≤ 1440
+        @test alloc_6 ≤ 1632
+    end
+end


### PR DESCRIPTION
This PR reduces allocations for 6 & 7-card hand evaluations by avoiding making a tuple of all card combinations, and instead evaluates and tracks each 5-card hand rank. We're also adding a test for the allocations