### PR TITLE
Add type annotation to evaluate5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PokerHandEvaluator"
 uuid = "18ed25b1-892a-4a3b-b8fc-1036dc9a6a89"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/evaluate5.jl
+++ b/src/evaluate5.jl
@@ -26,7 +26,7 @@ evaluate5(cards::Card...)::Int = evaluate5(cards)
 # for which a method, `evaluate_offsuit` and
 # `evaluate_flush` are defined. First, we dispatch
 # based on flush/non-flush:
-function evaluate5(t::NTuple{N,Card}) where {N}
+function evaluate5(t::NTuple{N,Card})::Int where {N}
     @assert N == 5
     if suit(t[1]) == suit(t[2]) == suit(t[3]) == suit(t[4]) == suit(t[5])
         evaluate5_flush(Val(prod(prime.(t))))


### PR DESCRIPTION
This allows the compiler to infer that `Int64` is returned from `evaluate5`.